### PR TITLE
Runsh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
-googleapis-common-protos==1.60.0
-grpclib==0.4.5
-h2==4.1.0
-hpack==4.0.0
-hyperframe==6.0.1
-multidict==6.0.4
-numpy==1.25.2
-opencv-python==4.8.0.76
-Pillow==10.0.0
-protobuf==4.24.2
-typing_extensions==4.7.1
-viam-sdk==0.5.1
+viam-sdk==0.7.0

--- a/run.sh
+++ b/run.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
+
+#
+# this file is used to build out our virtual environment
+# and add any environment variables needed to our run.sh
+# script
+#
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Create virtual Python environment
-cd `dirname $0`
-python3 -m venv --system-site-packages venv
+#
+# export which should contain ROS env (see INSTALL.md)
+#
+. /etc/viam/setup.bash
 
-./venv/bin/python3 -m pip install -r requirements.txt
+#
+# setup of virtual environment if it does not already exist
+#
+if [[ ! -f ${SCRIPT_DIR}/venv/bin/python ]]; then
+  echo "Setting up virtual environment & installing requirements"
+  python3 -m venv ${SCRIPT_DIR}/venv --system-site-packages
+  ${SCRIPT_DIR}/venv/bin/python -m pip install -r ${SCRIPT_DIR}/requirements.txt
+else
+  echo "virtual environment exists, will not run setup"
+fi
 
-# export underlay & add overlays as needed
-. /etc/turtlebot4/setup.bash
-. /opt/ros/humble/setup.bash
 
-# setup LD_LIBRARY_PATH for viam
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/python3.10/dist-packages/viam/rpc/:${SCRIPT_DIR}/venv/lib/python3.10/site-packages/viam/rpc/
+# setup LD_LIBRARY_PATH for viam rpc code (needed by RosImu)
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SCRIPT_DIR}/venv/lib/python3.10/site-packages/viam/rpc
 
-# TODO: ctrl-c seems to kill the run.sh script while leaving the child process running
-exec ${SCRIPT_DIR}/venv/bin/python3 ${SCRIPT_DIR}/src/main.py $@
+exec "${SCRIPT_DIR}"/venv/bin/python3 "${SCRIPT_DIR}"/src/main.py "$@"


### PR DESCRIPTION
@felixreichenbach lets review tomorrow

Changes:
1. validate python venv exists, if not set up the virtual environment
2. removed turtlebot source, introduced /etc/viam/setup.bash to support non-turtlebot ros robots
3. simplified requirments.txt, ensuring we do not cause ros2 conflicts