### PR TITLE
Adding Jira link and contribution guidelines that match python sdk repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
+
+## Types of Contributions
+
+### Report Bugs
+
+If you are reporting a bug, please include:
+
+- Your operating system name and version.
+- Any details about your local setup that might be helpful in troubleshooting.
+- Detailed steps to reproduce the bug.
+
+[Link to submit](https://viam.atlassian.net/servicedesk/customer/portal/7)
+
+### Fix Bugs
+
+Look through the [Jira tickets](???) for bug ticket types.
+
+### Implement Features
+
+Look through the [Jira tickets](???) for features which are "task" ticket types.
+
+### Write Documentation
+
+You can never have enough documentation! Please feel free to contribute to any
+part of the documentation, such as the official docs, docstrings, or even
+on the web in blog posts, articles, and such.
+
+### Submit Feedback
+
+If you are proposing a feature:
+
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+## Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include additional tests if appropriate.
+2. If the pull request adds functionality, the docs should be updated.
+3. The pull request should work for all currently supported operating systems and versions of Python.
+
+## Code of Conduct
+
+Please note that the `viam` project is released with a
+Code of Conduct. By contributing to this project you agree to abide by its terms.


### PR DESCRIPTION
I was at the Viam event last night and Nick (@HipsterBrown  - think that is the right tag) was saying he wanted to add a jira link to this repo. 

I thought I would be able to find the correct Jira board from the link the python sdk people gave me but I don't think I can :P Which board should I be linking to?